### PR TITLE
Improve editor wrapping and settings UX

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,40 @@
+# Seditor Agent Notes
+
+## Product Context
+
+Seditor is a lightweight desktop Markdown editor built with Tauri, React, and CodeMirror. The product direction is local-first editing with fast startup, reliable file handling, and a high-quality Markdown preview.
+
+Important user-facing surfaces:
+
+- Markdown editing with CodeMirror 6.
+- Preview with GFM, KaTeX, Mermaid, syntax highlighting, task lists, links, and an outline.
+- Recent files, session restore, reload from disk, save/save-as, and unsaved-change protection.
+- Appearance settings for accent color, font, font size, line wrapping, long-line handling, auto save, and custom CSS.
+
+## Local Commands
+
+```bash
+npm install
+npm run dev
+npm run check
+npm test
+npm run tauri dev
+```
+
+`npm run check` runs TypeScript without emitting files. `npm test` runs Rust tests through `cargo test --manifest-path src-tauri/Cargo.toml`.
+
+## Implementation Notes
+
+- Keep the editor local-first. Do not add cloud, account, telemetry, or remote persistence behavior unless explicitly requested.
+- Use existing React/Tailwind patterns and the shared UI components in `src/components/ui`.
+- Tauri APIs should stay behind small utility or hook boundaries when possible.
+- Settings are persisted in `localStorage` under `seditor:*` keys.
+- Avoid permission prompts on initial render. Ask for OS-level capabilities only from an explicit user action.
+- Preview outline should remain stable and predictable. Avoid width-zero animated sidebars or layout shifts that make the reading area jump unexpectedly.
+- Long-line handling must not hide content. Prefer wrapping or horizontal scroll over clipping.
+
+## Docs Summary
+
+The README positions Seditor as a native-feeling Markdown editor with rich preview quality similar to note-taking apps. The competitive review highlights recent files, session restore, status information, and future candidates such as multi-document tabs, spellcheck, split editor/preview mode, and export presets.
+
+When changing UX, prioritize the workflows implied by those docs: opening files quickly, preserving work safely, reading Markdown comfortably, and keeping controls low-friction.

--- a/agent.md
+++ b/agent.md
@@ -31,7 +31,7 @@ npm run tauri dev
 - Settings are persisted in `localStorage` under `seditor:*` keys.
 - Avoid permission prompts on initial render. Ask for OS-level capabilities only from an explicit user action.
 - Preview outline should remain stable and predictable. Avoid width-zero animated sidebars or layout shifts that make the reading area jump unexpectedly.
-- Long-line handling must not hide content. Prefer wrapping or horizontal scroll over clipping.
+- Long-line handling must not hide content. Word wrap is on by default and should use CodeMirror line wrapping, matching VS Code-style right-edge wrapping.
 
 ## Docs Summary
 

--- a/src/App.css
+++ b/src/App.css
@@ -81,20 +81,6 @@
   background: var(--text-muted);
 }
 
-/* ========================================
-   Editor — Overflow / Fold
-   ======================================== */
-
-.overflow-fold .cm-content {
-  white-space: pre !important;
-  overflow-wrap: normal !important;
-}
-
-.overflow-fold .cm-line {
-  overflow: hidden !important;
-  text-overflow: clip !important;
-}
-
 .fold-icon {
   color: var(--text-faint);
   cursor: pointer;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,24 @@ const WelcomeModal = lazy(async () => {
   return { default: module.WelcomeModal };
 });
 
+const DEFAULT_WORD_WRAP = true;
+const WELCOME_SEEN_KEY = "seditor:welcomeSeen";
+
+function readStoredWordWrap() {
+  const storedOverflowFold = localStorage.getItem("seditor:overflowFold");
+  const storedLineWrap = localStorage.getItem("seditor:lineWrap");
+
+  if (storedOverflowFold !== null) {
+    return storedOverflowFold === "true";
+  }
+
+  if (storedLineWrap !== null) {
+    return storedLineWrap === "true";
+  }
+
+  return DEFAULT_WORD_WRAP;
+}
+
 function App() {
   const viewRef = useRef<EditorView | null>(null);
   const {
@@ -89,10 +107,10 @@ function App() {
   const [showRecentFiles, setShowRecentFiles] = useState(false);
   const [showWelcome, setShowWelcome] = useState(false);
   const [lineWrapEnabled, setLineWrapEnabled] = useState(
-    localStorage.getItem("seditor:lineWrap") === "true"
+    readStoredWordWrap
   );
   const [overflowFoldEnabled, setOverflowFoldEnabled] = useState(
-    localStorage.getItem("seditor:overflowFold") === "true"
+    readStoredWordWrap
   );
   const [autoSaveEnabled, setAutoSaveEnabled] = useState(
     localStorage.getItem("seditor:autoSave") === "true"
@@ -178,9 +196,14 @@ function App() {
 
   useEffect(() => {
     const versionKey = `seditor:welcomeSeen:${packageJson.version}`;
-    if (!localStorage.getItem(versionKey)) {
+    if (localStorage.getItem(WELCOME_SEEN_KEY) || localStorage.getItem(versionKey)) {
+      localStorage.setItem(WELCOME_SEEN_KEY, "true");
+      return;
+    }
+
+    if (!localStorage.getItem(WELCOME_SEEN_KEY)) {
       setShowWelcome(true);
-      localStorage.setItem(versionKey, "true");
+      localStorage.setItem(WELCOME_SEEN_KEY, "true");
     }
   }, []);
 

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -63,8 +63,7 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
             Access settings via the cog icon to customize:
             <ul className="list-disc list-inside ml-2 mt-1 space-y-1">
                 <li>Font Family & Size</li>
-                <li>Line Wrapping</li>
-                <li>Overflow Folding (Horizontal clip)</li>
+                <li>VS Code-style word wrap</li>
                 <li>Auto Save</li>
                 <li>Recent Files history</li>
                 <li>Session Restore</li>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import {
   DEFAULT_FONT_SIZE,
 } from "../utils/theme";
 const DEFAULT_AUTO_SAVE = false;
+const DEFAULT_WORD_WRAP = true;
 const DEFAULT_REMEMBER_RECENT_FILES = true;
 const DEFAULT_RESTORE_LAST_SESSION = true;
 
@@ -28,6 +29,21 @@ interface SettingsPanelProps {
   onClose: () => void;
 }
 
+function readStoredWordWrap() {
+  const storedOverflowFold = localStorage.getItem("seditor:overflowFold");
+  const storedLineWrap = localStorage.getItem("seditor:lineWrap");
+
+  if (storedOverflowFold !== null) {
+    return storedOverflowFold === "true";
+  }
+
+  if (storedLineWrap !== null) {
+    return storedLineWrap === "true";
+  }
+
+  return DEFAULT_WORD_WRAP;
+}
+
 export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   isOpen,
   onClose,
@@ -45,8 +61,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     localStorage.getItem("seditor:customCss") || ""
   );
   const [overflowFold, setOverflowFold] = useState<boolean>(
-    localStorage.getItem("seditor:overflowFold") === "true" ||
-      localStorage.getItem("seditor:lineWrap") === "true"
+    readStoredWordWrap
   );
   const [autoSave, setAutoSave] = useState<boolean>(
     localStorage.getItem("seditor:autoSave") === "true"
@@ -169,7 +184,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     setFontFamily(DEFAULT_FONT);
     setFontSize(DEFAULT_FONT_SIZE);
     setCustomCss("");
-    setOverflowFold(false);
+    setOverflowFold(DEFAULT_WORD_WRAP);
     setAutoSave(DEFAULT_AUTO_SAVE);
     setRememberRecentFiles(DEFAULT_REMEMBER_RECENT_FILES);
     setRestoreLastSession(DEFAULT_RESTORE_LAST_SESSION);
@@ -177,8 +192,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     window.dispatchEvent(
       new CustomEvent("seditor:settingsChanged", {
         detail: {
-          lineWrap: false,
-          overflowFold: false,
+          lineWrap: DEFAULT_WORD_WRAP,
+          overflowFold: DEFAULT_WORD_WRAP,
           autoSave: DEFAULT_AUTO_SAVE,
           rememberRecentFiles: DEFAULT_REMEMBER_RECENT_FILES,
           restoreLastSession: DEFAULT_RESTORE_LAST_SESSION,

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -44,11 +44,9 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const [customCss, setCustomCss] = useState<string>(
     localStorage.getItem("seditor:customCss") || ""
   );
-  const [lineWrap, setLineWrap] = useState<boolean>(
-    localStorage.getItem("seditor:lineWrap") === "true"
-  );
   const [overflowFold, setOverflowFold] = useState<boolean>(
-    localStorage.getItem("seditor:overflowFold") === "true"
+    localStorage.getItem("seditor:overflowFold") === "true" ||
+      localStorage.getItem("seditor:lineWrap") === "true"
   );
   const [autoSave, setAutoSave] = useState<boolean>(
     localStorage.getItem("seditor:autoSave") === "true"
@@ -64,37 +62,50 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const [systemFonts, setSystemFonts] = useState<string[]>([]);
   const [fontSearch, setFontSearch] = useState("");
   const [showFontDropdown, setShowFontDropdown] = useState(false);
+  const [fontPermissionError, setFontPermissionError] = useState("");
+  const [systemFontsLoaded, setSystemFontsLoaded] = useState(false);
   const fontDropdownRef = useRef<HTMLDivElement>(null);
   const fontInputRef = useRef<HTMLInputElement>(null);
 
-  // Load system fonts
   useEffect(() => {
-    if (!isOpen) {
-      return;
+    setSystemFonts(FALLBACK_FONTS);
+  }, []);
+
+  const loadSystemFonts = async () => {
+    setFontPermissionError("");
+
+    try {
+      if ("queryLocalFonts" in window) {
+        const fonts = await (window as any).queryLocalFonts();
+        const familySet = new Set<string>();
+        for (const font of fonts) {
+          familySet.add(font.family);
+        }
+        const sorted = Array.from(familySet).sort((a, b) =>
+          a.localeCompare(b, "ja")
+        );
+        setSystemFonts(sorted.length > 0 ? sorted : FALLBACK_FONTS);
+        setSystemFontsLoaded(true);
+        setShowFontDropdown(true);
+        return;
+      }
+    } catch {
+      setFontPermissionError("権限が許可されなかったため、標準フォント一覧を表示しています。");
     }
 
-    const loadFonts = async () => {
-      try {
-        // Local Font Access API (Chromium / Tauri WebView2)
-        if ("queryLocalFonts" in window) {
-          const fonts = await (window as any).queryLocalFonts();
-          const familySet = new Set<string>();
-          for (const font of fonts) {
-            familySet.add(font.family);
-          }
-          const sorted = Array.from(familySet).sort((a, b) =>
-            a.localeCompare(b, "ja")
-          );
-          setSystemFonts(sorted);
-          return;
-        }
-      } catch {
-        // Permission denied or API not available
-      }
-      // Fallback
+    setSystemFontsLoaded(false);
+    setSystemFonts(FALLBACK_FONTS);
+    setShowFontDropdown(true);
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      setShowFontDropdown(false);
+      setFontSearch("");
+      setFontPermissionError("");
       setSystemFonts(FALLBACK_FONTS);
-    };
-    loadFonts();
+      setSystemFontsLoaded(false);
+    }
   }, [isOpen]);
 
   // Close dropdown when clicking outside
@@ -122,7 +133,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     localStorage.setItem("seditor:accentColor", accentColor);
     localStorage.setItem("seditor:fontFamily", fontFamily);
     localStorage.setItem("seditor:fontSize", String(fontSize));
-    localStorage.setItem("seditor:lineWrap", String(lineWrap));
+    localStorage.setItem("seditor:lineWrap", String(overflowFold));
     localStorage.setItem("seditor:overflowFold", String(overflowFold));
     localStorage.setItem("seditor:autoSave", String(autoSave));
     localStorage.setItem("seditor:rememberRecentFiles", String(rememberRecentFiles));
@@ -132,7 +143,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     
     window.dispatchEvent(
       new CustomEvent("seditor:settingsChanged", {
-        detail: { lineWrap, overflowFold, autoSave, rememberRecentFiles, restoreLastSession },
+        detail: {
+          lineWrap: overflowFold,
+          overflowFold,
+          autoSave,
+          rememberRecentFiles,
+          restoreLastSession,
+        },
       })
     );
     onClose();
@@ -152,7 +169,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     setFontFamily(DEFAULT_FONT);
     setFontSize(DEFAULT_FONT_SIZE);
     setCustomCss("");
-    setLineWrap(false);
     setOverflowFold(false);
     setAutoSave(DEFAULT_AUTO_SAVE);
     setRememberRecentFiles(DEFAULT_REMEMBER_RECENT_FILES);
@@ -222,22 +238,32 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           <label className="block text-sm font-medium mb-1.5" style={labelStyle}>
             フォント
           </label>
-          <input
-            ref={fontInputRef}
-            type="text"
-            className="w-full px-3 py-2 border focus:outline-none text-sm"
-            style={{ ...inputStyle, fontFamily: fontFamily }}
-            value={showFontDropdown ? fontSearch : fontFamily}
-            placeholder="フォント名を検索..."
-            onFocus={() => {
-              setShowFontDropdown(true);
-              setFontSearch("");
-            }}
-            onChange={(e) => {
-              setFontSearch(e.target.value);
-              if (!showFontDropdown) setShowFontDropdown(true);
-            }}
-          />
+          <div className="flex gap-2">
+            <input
+              ref={fontInputRef}
+              type="text"
+              className="min-w-0 flex-1 px-3 py-2 border focus:outline-none text-sm"
+              style={{ ...inputStyle, fontFamily: fontFamily }}
+              value={showFontDropdown ? fontSearch : fontFamily}
+              placeholder="フォント名を検索..."
+              onFocus={() => {
+                setShowFontDropdown(true);
+                setFontSearch("");
+              }}
+              onChange={(e) => {
+                setFontSearch(e.target.value);
+                if (!showFontDropdown) setShowFontDropdown(true);
+              }}
+            />
+            <Button variant="outline" type="button" onClick={loadSystemFonts}>
+              {systemFontsLoaded ? "再読込" : "読込"}
+            </Button>
+          </div>
+          {fontPermissionError && (
+            <p className="mt-1 text-xs" style={{ color: "var(--text-faint)" }}>
+              {fontPermissionError}
+            </p>
+          )}
           {showFontDropdown && (
             <div
               className="absolute left-0 right-0 mt-1 border overflow-y-auto z-50"
@@ -287,25 +313,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           <div className="flex items-center gap-2">
             <input
               type="checkbox"
-              id="lineWrap"
-              style={{ accentColor: accentColor }}
-              checked={lineWrap}
-              onChange={(e) => setLineWrap(e.target.checked)}
-            />
-            <label htmlFor="lineWrap" className="text-sm" style={{ color: 'var(--text-normal)' }}>
-              行の折り返し
-            </label>
-          </div>
-          <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
               id="overflowFold"
               style={{ accentColor: accentColor }}
               checked={overflowFold}
               onChange={(e) => setOverflowFold(e.target.checked)}
             />
             <label htmlFor="overflowFold" className="text-sm" style={{ color: 'var(--text-normal)' }}>
-              はみ出し折りたたみ
+              右端で折り返し (VS Code Word Wrap)
             </label>
           </div>
           <div className="flex items-center gap-2">

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -83,6 +83,7 @@ export const Editor: React.FC<EditorProps> = ({
   const viewRef = useRef<EditorView | null>(null);
   const applyingExternalChangeRef = useRef(false);
   const lineWrappingComp = useRef(new Compartment());
+  const shouldWrapLines = lineWrap || overflowFold;
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -103,7 +104,7 @@ export const Editor: React.FC<EditorProps> = ({
             return el;
           }
         }),
-        lineWrappingComp.current.of(lineWrap ? EditorView.lineWrapping : []),
+        lineWrappingComp.current.of(shouldWrapLines ? EditorView.lineWrapping : []),
         history(),
         markdown(),
         editorTheme,
@@ -168,23 +169,16 @@ export const Editor: React.FC<EditorProps> = ({
     if (viewRef.current) {
       viewRef.current.dispatch({
         effects: lineWrappingComp.current.reconfigure(
-          lineWrap ? EditorView.lineWrapping : []
+          shouldWrapLines ? EditorView.lineWrapping : []
         ),
       });
     }
-  }, [lineWrap]);
-
-  useEffect(() => {
-    if (containerRef.current) {
-        if (overflowFold) containerRef.current.classList.add("overflow-fold");
-        else containerRef.current.classList.remove("overflow-fold");
-    }
-  }, [overflowFold]);
+  }, [shouldWrapLines]);
 
   return (
     <div 
       ref={containerRef} 
-      className={`h-full w-full text-left ${overflowFold ? "overflow-fold" : ""}`} 
+      className="h-full w-full text-left"
     />
   );
 };

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -167,6 +167,7 @@ export const Preview: React.FC<PreviewProps> = ({
         };
       });
       setHeadings(items);
+      setActiveId((current) => current || items[0]?.id || null);
     }, 100);
 
     const handleScroll = () => {
@@ -196,19 +197,24 @@ export const Preview: React.FC<PreviewProps> = ({
 
   return (
     <div className="flex h-full relative">
-       <button
-        onClick={() => setShowOutline(!showOutline)}
-        className="absolute top-4 right-6 z-10 p-2 rounded-none transition-all backdrop-blur-sm shadow-sm border"
-        style={{ color: 'var(--text-faint)', backgroundColor: 'var(--toolbar-glass)', borderColor: 'var(--toolbar-border)' }}
-        title={showOutline ? "Hide Outline" : "Show Outline"}
+      <button
+        onClick={() => setShowOutline((current) => !current)}
+        className="absolute right-4 top-4 z-10 flex h-9 w-9 items-center justify-center border transition-colors"
+        style={{
+          color: showOutline ? "var(--text-normal)" : "var(--text-faint)",
+          backgroundColor: "var(--toolbar-glass)",
+          borderColor: "var(--toolbar-border)",
+        }}
+        aria-pressed={showOutline}
+        title={showOutline ? "目次を隠す" : "目次を表示"}
       >
         <FiSidebar size={16} />
       </button>
 
-      <div className="flex-1 overflow-y-auto preview-scroll-container px-8 py-8 transition-all duration-300">
+      <div className="flex-1 overflow-y-auto preview-scroll-container px-8 py-8">
         <div 
           ref={previewRef}
-          className={`markdown-preview-view prose max-w-3xl ${showOutline ? "mr-4" : "mx-auto"} ml-auto prose-headings:scroll-mt-20 pb-32`} 
+          className="markdown-preview-view prose mx-auto max-w-3xl prose-headings:scroll-mt-20 pb-32"
           style={{ color: '#1e1e2e' }}
         >
           <ReactMarkdown
@@ -350,17 +356,19 @@ export const Preview: React.FC<PreviewProps> = ({
         </div>
       </div>
       
-      <div className={`
-        flex-shrink-0 border-l h-full overflow-y-auto
-        transition-all duration-300 ease-in-out
-        ${showOutline ? "w-64 opacity-100 translate-x-0" : "w-0 opacity-0 translate-x-10 p-0 border-none"}
-      `}
-      style={{ borderLeftColor: 'var(--background-modifier-border)', backgroundColor: 'var(--bg-primary-alt)' }}
-      >
+      {showOutline && headings.length > 0 && (
+        <aside
+          className="h-full w-64 flex-shrink-0 overflow-y-auto border-l"
+          style={{
+            borderLeftColor: "var(--background-modifier-border)",
+            backgroundColor: "var(--bg-primary-alt)",
+          }}
+        >
           <div className="pt-16 px-0 h-full">
             <Outline headings={headings} activeId={activeId || undefined} onClick={scrollToId} />
           </div>
-      </div>
+        </aside>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Closes #7

## Summary
- Replace the awkward long-line clipping behavior with VS Code-style word wrap through CodeMirror line wrapping.
- Reduce repeated permission prompts in Settings by only querying local system fonts from an explicit user action.
- Stabilize the preview outline toggle so hiding/showing it does not use a width-zero animated sidebar.
- Add agent.md with project context, docs summary, and development notes.

## Validation
- npm.cmd run check
- npm.cmd test could not complete locally because the MSVC linker link.exe is not installed in this environment.