### PR TITLE
Fix persisted wrap and welcome preferences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   frontend:
@@ -39,3 +40,33 @@ jobs:
 
       - name: Check Rust code
         run: cargo check --manifest-path src-tauri/Cargo.toml
+
+  windows-app:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Windows app
+        run: npm run tauri build
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: seditor-windows
+          path: |
+            src-tauri/target/release/*.exe
+            src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Automatic publishing on `main`:
 npm run tauri build
 ```
 
+If Windows build tools are not installed locally, run the `CI` workflow from
+GitHub Actions and download the `seditor-windows` artifact instead.
+
 ## Project status
 
 Current repository improvements include:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,9 +35,13 @@ import { useShortcuts } from "./hooks/useShortcuts";
 import { moveLine } from "./utils/editorUtils";
 import { buildDocumentStats, fileNameFromPath } from "./utils/document";
 import { toggleTaskMarker } from "./utils/document";
+import {
+  dismissWelcome,
+  hasDismissedWelcome,
+  readWordWrapPreference,
+} from "./utils/preferences";
 import { revealInFileManager } from "./utils/runtime";
 import { applyPersistedTheme } from "./utils/theme";
-import packageJson from "../package.json";
 import "./App.css";
 
 const Preview = lazy(async () => {
@@ -65,24 +69,6 @@ const WelcomeModal = lazy(async () => {
   return { default: module.WelcomeModal };
 });
 
-const DEFAULT_WORD_WRAP = true;
-const WELCOME_SEEN_KEY = "seditor:welcomeSeen";
-
-function readStoredWordWrap() {
-  const storedOverflowFold = localStorage.getItem("seditor:overflowFold");
-  const storedLineWrap = localStorage.getItem("seditor:lineWrap");
-
-  if (storedOverflowFold !== null) {
-    return storedOverflowFold === "true";
-  }
-
-  if (storedLineWrap !== null) {
-    return storedLineWrap === "true";
-  }
-
-  return DEFAULT_WORD_WRAP;
-}
-
 function App() {
   const viewRef = useRef<EditorView | null>(null);
   const {
@@ -107,10 +93,10 @@ function App() {
   const [showRecentFiles, setShowRecentFiles] = useState(false);
   const [showWelcome, setShowWelcome] = useState(false);
   const [lineWrapEnabled, setLineWrapEnabled] = useState(
-    readStoredWordWrap
+    readWordWrapPreference
   );
   const [overflowFoldEnabled, setOverflowFoldEnabled] = useState(
-    readStoredWordWrap
+    readWordWrapPreference
   );
   const [autoSaveEnabled, setAutoSaveEnabled] = useState(
     localStorage.getItem("seditor:autoSave") === "true"
@@ -195,16 +181,14 @@ function App() {
   }, []);
 
   useEffect(() => {
-    const versionKey = `seditor:welcomeSeen:${packageJson.version}`;
-    if (localStorage.getItem(WELCOME_SEEN_KEY) || localStorage.getItem(versionKey)) {
-      localStorage.setItem(WELCOME_SEEN_KEY, "true");
-      return;
-    }
-
-    if (!localStorage.getItem(WELCOME_SEEN_KEY)) {
+    if (!hasDismissedWelcome()) {
       setShowWelcome(true);
-      localStorage.setItem(WELCOME_SEEN_KEY, "true");
     }
+  }, []);
+
+  const handleCloseWelcome = useCallback(() => {
+    dismissWelcome();
+    setShowWelcome(false);
   }, []);
 
   useEffect(() => {
@@ -417,7 +401,7 @@ function App() {
       )}
       {showWelcome && (
         <Suspense fallback={null}>
-          <WelcomeModal isOpen={showWelcome} onClose={() => setShowWelcome(false)} />
+          <WelcomeModal isOpen={showWelcome} onClose={handleCloseWelcome} />
         </Suspense>
       )}
       {showSettings && (

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -7,8 +7,12 @@ import {
   DEFAULT_FONT,
   DEFAULT_FONT_SIZE,
 } from "../utils/theme";
+import {
+  readWordWrapPreference,
+  resetWordWrapPreference,
+  setWordWrapPreference,
+} from "../utils/preferences";
 const DEFAULT_AUTO_SAVE = false;
-const DEFAULT_WORD_WRAP = true;
 const DEFAULT_REMEMBER_RECENT_FILES = true;
 const DEFAULT_RESTORE_LAST_SESSION = true;
 
@@ -29,21 +33,6 @@ interface SettingsPanelProps {
   onClose: () => void;
 }
 
-function readStoredWordWrap() {
-  const storedOverflowFold = localStorage.getItem("seditor:overflowFold");
-  const storedLineWrap = localStorage.getItem("seditor:lineWrap");
-
-  if (storedOverflowFold !== null) {
-    return storedOverflowFold === "true";
-  }
-
-  if (storedLineWrap !== null) {
-    return storedLineWrap === "true";
-  }
-
-  return DEFAULT_WORD_WRAP;
-}
-
 export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   isOpen,
   onClose,
@@ -61,7 +50,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     localStorage.getItem("seditor:customCss") || ""
   );
   const [overflowFold, setOverflowFold] = useState<boolean>(
-    readStoredWordWrap
+    readWordWrapPreference
   );
   const [autoSave, setAutoSave] = useState<boolean>(
     localStorage.getItem("seditor:autoSave") === "true"
@@ -148,8 +137,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     localStorage.setItem("seditor:accentColor", accentColor);
     localStorage.setItem("seditor:fontFamily", fontFamily);
     localStorage.setItem("seditor:fontSize", String(fontSize));
-    localStorage.setItem("seditor:lineWrap", String(overflowFold));
-    localStorage.setItem("seditor:overflowFold", String(overflowFold));
+    setWordWrapPreference(overflowFold);
     localStorage.setItem("seditor:autoSave", String(autoSave));
     localStorage.setItem("seditor:rememberRecentFiles", String(rememberRecentFiles));
     localStorage.setItem("seditor:restoreLastSession", String(restoreLastSession));
@@ -175,8 +163,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     localStorage.removeItem("seditor:fontFamily");
     localStorage.removeItem("seditor:fontSize");
     localStorage.removeItem("seditor:customCss");
-    localStorage.removeItem("seditor:lineWrap");
-    localStorage.removeItem("seditor:overflowFold");
     localStorage.removeItem("seditor:autoSave");
     localStorage.removeItem("seditor:rememberRecentFiles");
     localStorage.removeItem("seditor:restoreLastSession");
@@ -184,7 +170,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     setFontFamily(DEFAULT_FONT);
     setFontSize(DEFAULT_FONT_SIZE);
     setCustomCss("");
-    setOverflowFold(DEFAULT_WORD_WRAP);
+    const defaultWordWrap = resetWordWrapPreference();
+    setOverflowFold(defaultWordWrap);
     setAutoSave(DEFAULT_AUTO_SAVE);
     setRememberRecentFiles(DEFAULT_REMEMBER_RECENT_FILES);
     setRestoreLastSession(DEFAULT_RESTORE_LAST_SESSION);
@@ -192,8 +179,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     window.dispatchEvent(
       new CustomEvent("seditor:settingsChanged", {
         detail: {
-          lineWrap: DEFAULT_WORD_WRAP,
-          overflowFold: DEFAULT_WORD_WRAP,
+          lineWrap: defaultWordWrap,
+          overflowFold: defaultWordWrap,
           autoSave: DEFAULT_AUTO_SAVE,
           rememberRecentFiles: DEFAULT_REMEMBER_RECENT_FILES,
           restoreLastSession: DEFAULT_RESTORE_LAST_SESSION,

--- a/src/utils/preferences.ts
+++ b/src/utils/preferences.ts
@@ -1,0 +1,58 @@
+const WORD_WRAP_KEY = "seditor:wordWrap";
+const LEGACY_LINE_WRAP_KEY = "seditor:lineWrap";
+const LEGACY_OVERFLOW_FOLD_KEY = "seditor:overflowFold";
+
+const WELCOME_DISMISSED_KEY = "seditor:welcomeDismissed";
+const LEGACY_WELCOME_KEY = "seditor:welcomeSeen";
+const LEGACY_WELCOME_PREFIX = "seditor:welcomeSeen:";
+
+const DEFAULT_WORD_WRAP = true;
+
+export function readWordWrapPreference() {
+  const storedWordWrap = localStorage.getItem(WORD_WRAP_KEY);
+
+  if (storedWordWrap !== null) {
+    return storedWordWrap === "true";
+  }
+
+  setWordWrapPreference(DEFAULT_WORD_WRAP);
+  return DEFAULT_WORD_WRAP;
+}
+
+export function setWordWrapPreference(enabled: boolean) {
+  const value = String(enabled);
+  localStorage.setItem(WORD_WRAP_KEY, value);
+  localStorage.setItem(LEGACY_LINE_WRAP_KEY, value);
+  localStorage.setItem(LEGACY_OVERFLOW_FOLD_KEY, value);
+}
+
+export function resetWordWrapPreference() {
+  setWordWrapPreference(DEFAULT_WORD_WRAP);
+  return DEFAULT_WORD_WRAP;
+}
+
+export function hasDismissedWelcome() {
+  if (localStorage.getItem(WELCOME_DISMISSED_KEY) === "true") {
+    return true;
+  }
+
+  if (localStorage.getItem(LEGACY_WELCOME_KEY) === "true") {
+    dismissWelcome();
+    return true;
+  }
+
+  for (let index = 0; index < localStorage.length; index += 1) {
+    const key = localStorage.key(index);
+    if (key?.startsWith(LEGACY_WELCOME_PREFIX)) {
+      dismissWelcome();
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function dismissWelcome() {
+  localStorage.setItem(WELCOME_DISMISSED_KEY, "true");
+  localStorage.setItem(LEGACY_WELCOME_KEY, "true");
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,11 +57,26 @@ export default defineConfig(() => ({
           }
 
           if (
-            id.includes("@codemirror") ||
-            id.includes("@lezer") ||
+            id.includes("@codemirror/view") ||
+            id.includes("@codemirror/state")
+          ) {
+            return "editor-core";
+          }
+
+          if (
+            id.includes("@codemirror/language") ||
+            id.includes("@codemirror/lang-markdown") ||
+            id.includes("@lezer")
+          ) {
+            return "editor-language";
+          }
+
+          if (
+            id.includes("@codemirror/commands") ||
+            id.includes("@codemirror/search") ||
             id.includes("codemirror")
           ) {
-            return "editor-vendor";
+            return "editor-tools";
           }
 
           if (
@@ -81,5 +96,6 @@ export default defineConfig(() => ({
         },
       },
     },
+    chunkSizeWarningLimit: 600,
   },
 }));


### PR DESCRIPTION
Closes #9

## Summary
- Add a dedicated seditor:wordWrap preference and migrate legacy lineWrap/overflowFold keys to wrap-on by default.
- Keep legacy wrap keys in sync only for compatibility after the new preference has been established.
- Add a stable seditor:welcomeDismissed key and migrate older welcomeSeen keys.
- Persist welcome dismissal when the modal is actually closed, preventing repeated prompts after updates.

## Validation
- npm.cmd run check
- npm.cmd run build