### PR TITLE
Fix Tauri asset base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/demo.css" />
+    <link rel="stylesheet" href="%BASE_URL%demo.css" />
     <title>Seditor</title>
   </head>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 
 
 const host = process.env.TAURI_DEV_HOST;
-const base = process.env.VITE_BASE_PATH || "/";
+const base = process.env.VITE_BASE_PATH || (process.env.TAURI_PLATFORM ? "./" : "/");
 
 // https://vite.dev/config/
 export default defineConfig(() => ({


### PR DESCRIPTION
Closes #11

## Summary
- Use a relative Vite base for Tauri builds so the desktop bundle loads scripts and styles from ./assets instead of /assets.
- Make public asset links in index.html use %BASE_URL%.

## Validation
- npm.cmd run check
- npm.cmd run build
- TAURI_PLATFORM=windows npm.cmd run build produced relative ./assets paths in dist/index.html